### PR TITLE
issue#33: display human readable block name in drop-down selections

### DIFF
--- a/classes/form/blocks_form.php
+++ b/classes/form/blocks_form.php
@@ -17,6 +17,7 @@
 namespace tool_blocksmanager\form;
 
 use tool_blocksmanager\block;
+use tool_blocksmanager\helper;
 
 /**
  * Form to manipulate with blocks.
@@ -44,12 +45,7 @@ class blocks_form extends \core\form\persistent {
         $regions = implode(', ', array_keys([block::ALL_REGIONS => ''] + $PAGE->theme->get_all_block_regions()));
         $mform->addElement('static', 'availableregions', get_string('availableregions', 'tool_blocksmanager'), $regions);
 
-        $blocks = [];
-        foreach ($PAGE->blocks->get_installed_blocks() as $block) {
-            $blocks[$block->name] = $block->name;
-        }
-
-        $mform->addElement('select', 'block', get_string('field_block', 'tool_blocksmanager'), $blocks);
+        $mform->addElement('select', 'block', get_string('field_block', 'tool_blocksmanager'), helper::get_installed_blocks());
 
         $mform->addElement('select',
             'categories',

--- a/classes/form/setup_form.php
+++ b/classes/form/setup_form.php
@@ -17,6 +17,7 @@
 namespace tool_blocksmanager\form;
 
 use tool_blocksmanager\block_manager;
+use tool_blocksmanager\helper;
 use tool_blocksmanager\invalid_setup_item_exception;
 use tool_blocksmanager\setup_item;
 
@@ -35,11 +36,6 @@ class setup_form extends \moodleform {
     protected function definition() {
         global $PAGE;
 
-        $blocks = [];
-        foreach ($PAGE->blocks->get_installed_blocks() as $block) {
-            $blocks[$block->name] = $block->name;
-        }
-
         $weightoptions = [];
         for ($i = -block_manager::MAX_WEIGHT; $i <= block_manager::MAX_WEIGHT; $i++) {
             $weightoptions[$i] = $i;
@@ -54,7 +50,12 @@ class setup_form extends \moodleform {
         $this->_form->addElement('static', 'availableregions', get_string('availableregions', 'tool_blocksmanager'), $regions);
         $this->_form->addElement('text', 'region', get_string('field_region', 'tool_blocksmanager'));
         $this->_form->setType('region', PARAM_TEXT);
-        $this->_form->addElement('select', 'block', get_string('field_block', 'tool_blocksmanager'), $blocks);
+        $this->_form->addElement(
+            'select',
+            'block',
+            get_string('field_block', 'tool_blocksmanager'),
+            helper::get_installed_blocks()
+        );
         $this->_form->addElement('select', 'categories', get_string('field_categories', 'tool_blocksmanager'),
             \core_course_category::make_categories_list(), ['multiple' => true]);
         $this->_form->addElement('select', 'weight', get_string('weight', 'block'), $weightoptions);

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -53,4 +53,21 @@ class helper {
         return array_unique($result);
     }
 
+    /**
+     * Returns a list of all installed blocks where key is a short
+     * block name e.g. online_users and value is human readable name e.g. Online users
+     *
+     * @return array
+     */
+    public static function get_installed_blocks(): array {
+        global $PAGE;
+
+        $blocks = [];
+        foreach ($PAGE->blocks->get_installed_blocks() as $block) {
+            $blocks[$block->name] = get_string('pluginname', 'block_' . $block->name);
+        }
+
+        return  $blocks;
+    }
+
 }

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -23,7 +23,7 @@ namespace tool_blocksmanager;
  * @copyright   2019 Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class blocksmanager_helper_test extends \advanced_testcase {
+class helper_test extends \advanced_testcase {
 
     /**
      * Initial set up.
@@ -46,28 +46,45 @@ class blocksmanager_helper_test extends \advanced_testcase {
 
         $this->assertSame(
             [$category1->id, $category11->id, $category111->id],
-            \tool_blocksmanager\helper::get_categories_and_children($category1->id)
+            helper::get_categories_and_children($category1->id)
         );
 
         $this->assertSame(
             [$category11->id, $category111->id],
-            \tool_blocksmanager\helper::get_categories_and_children($category11->id)
+            helper::get_categories_and_children($category11->id)
         );
 
         $this->assertSame(
             [$category111->id],
-            \tool_blocksmanager\helper::get_categories_and_children($category111->id)
+            helper::get_categories_and_children($category111->id)
         );
 
         $this->assertSame(
             [$category2->id],
-            \tool_blocksmanager\helper::get_categories_and_children($category2->id)
+            helper::get_categories_and_children($category2->id)
         );
 
         $this->assertSame(
             [$category1->id, $category11->id, $category111->id],
-            \tool_blocksmanager\helper::get_categories_and_children($category1->id . ',' . $category11->id)
+            helper::get_categories_and_children($category1->id . ',' . $category11->id)
         );
+    }
+
+    /**
+     * Test that we can build a list of installed blocks correctly.
+     *
+     * @covers \tool_blocksmanager\helper::get_installed_blocks
+     * @return void
+     */
+    public function test_get_installed_blocks() {
+        global $PAGE;
+
+        $expected = [];
+        foreach ($PAGE->blocks->get_installed_blocks() as $block) {
+            $expected[$block->name] = get_string('pluginname', 'block_' . $block->name);
+        }
+
+        $this->assertSame($expected, helper::get_installed_blocks());
     }
 
 }


### PR DESCRIPTION
This change modify plugin forms for displaying a human readable block name to be consistent with how core does that when you add a block to a page. 

**Before**:

![image](https://user-images.githubusercontent.com/4626431/235829448-bd2acc2f-9da7-4325-822d-700e956aab3d.png)


**After**:

![image](https://user-images.githubusercontent.com/4626431/235829490-305168c7-5294-4078-9145-63f8ed5b75d3.png)
