### PR TITLE
issue #38: display full block name on the block management page

### DIFF
--- a/classes/table/region_list.php
+++ b/classes/table/region_list.php
@@ -26,6 +26,7 @@ namespace tool_blocksmanager\table;
 
 use core\persistent;
 use tool_blocksmanager\base_controller;
+use tool_blocksmanager\helper;
 use tool_blocksmanager\region_controller;
 
 defined('MOODLE_INTERNAL') || die();
@@ -183,6 +184,10 @@ class region_list extends \flexible_table {
 
                 $display = implode('<BR />', $categories);
 
+                break;
+            case 'block':
+                $allblocks = helper::get_installed_blocks();
+                $display = $allblocks[$value] ?? $value;
                 break;
 
             case 'config':


### PR DESCRIPTION
**Before**

![image](https://user-images.githubusercontent.com/4626431/236390409-31f3853f-5ee9-44a3-abe7-609fc5a2ae02.png)


**After** 
![image](https://user-images.githubusercontent.com/4626431/236390298-abe63841-b4a8-4e78-83f9-478404544a4d.png)
